### PR TITLE
reproducible docker image failing

### DIFF
--- a/service_agent/Dockerfile
+++ b/service_agent/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:12-alpine
+
+
+#install CLI mariadb/mysql client
+#RUN apk add --update mariadb-client && apk add python3 && rm -rf /var/cache/apk/*
+
+# Create app directory
+WORKDIR /usr/src
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source & config files for TypeORM & TypeScript
+COPY ./src /usr/src
+
+RUN npm run start

--- a/service_agent/package.json
+++ b/service_agent/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "@hapi/hapi": "18",
     "@hapi/inert": "^6.0.1",
-    "@jolocom/sdk": "^1.1.0-rc4",
+    "@jolocom/sdk": "^1.2.0",
     "@jolocom/sdk-password-store-filesystem": "^0.2.2",
-    "@jolocom/sdk-storage-typeorm": "^4.1.0",
+    "@jolocom/sdk-storage-typeorm": "^5.0.0-rc0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "eslint": "^7.14.0",


### PR DESCRIPTION
Docker images are failing when embedding the sdk.

![image](https://user-images.githubusercontent.com/30729240/122644185-44473300-d114-11eb-843a-404cdd976ede.png)

To re-produce:
- cd service_agent
- docker build .

The above error will be generated.
